### PR TITLE
fix filter backtrace to include namespaced function

### DIFF
--- a/code/SentryLogWriter.php
+++ b/code/SentryLogWriter.php
@@ -164,7 +164,7 @@ class SentryLogWriter extends \Zend_Log_Writer_Abstract
             'timestamp' => strtotime($event['timestamp']),                  // From Zend_Log::log()
             'extra'     => isset($event['extra']) ? $event['extra'] : []    // From _config.php (Optional)
         ];
-        $trace = \SS_Backtrace::filter_backtrace(debug_backtrace(), ['SentryLogWriter->_write']);
+        $trace = \SS_Backtrace::filter_backtrace(debug_backtrace(), ['SentryLogWriter->_write', 'phptek\Sentry\SentryLogWriter->_write']);
         
         $this->client->send($message, [], $data, $trace);
     }


### PR DESCRIPTION
otherwise it's not filtered properly.

maybe it's not even necessary to add non namespaced function, but it cannot hurt to have it so I didn't remove it