### PR TITLE
BUG Remove private var that is now protected in monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": ">=5.6|<=7.2",
         "sentry/sentry": "^1.9",
+        "monolog/monolog": "^1.24.0",
         "silverstripe/framework": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
Resolves issue where private var crashes on override of existing protected in base

> Fatal error: Access level to PhpTek\Sentry\Monolog\Handler\SentryRavenHandler::$logLevels must be protected (as in class Monolog\Handler\RavenHandler) or weaker in /Users/damian.mooyman/Sites/testsite/vendor/phptek/sentry/src/Handler/SentryRavenHandler.php on line 23
