### PR TITLE
BUG Show actual stacktrace for errors / exceptions

### DIFF
--- a/src/Adaptor/RavenClient.php
+++ b/src/Adaptor/RavenClient.php
@@ -9,16 +9,16 @@
 
 namespace PhpTek\Sentry\Adaptor;
 
-use PhpTek\Sentry\Adaptor\SentryClientAdaptor,
-    phpTek\Sentry\Exception\SentryLogWriterException,
-    SilverStripe\Core\Config\Config;
+use phpTek\Sentry\Exception\SentryLogWriterException;
+use Raven_Client;
+use Raven_Exception;
+use SilverStripe\Core\Config\Config;
 
 /**
  * The RavenClient class simply acts as a bridge between the Raven PHP SDK and
  * the SentryLogWriter class itself. Any {@link SentryClientAdaptor} subclass
  * should be able to be swapped-out and used at any point.
  */
-
 class RavenClient extends SentryClientAdaptor
 {
 
@@ -41,20 +41,20 @@ class RavenClient extends SentryClientAdaptor
      * @var array
      */
     protected $logLevels = [
-        'NOTICE'    => \Raven_Client::INFO,
-        'WARN'      => \Raven_Client::WARNING,
-        'ERR'       => \Raven_Client::ERROR,
-        'EMERG'     => \Raven_Client::FATAL
+        'NOTICE' => Raven_Client::INFO,
+        'WARN'   => Raven_Client::WARNING,
+        'ERR'    => Raven_Client::ERROR,
+        'EMERG'  => Raven_Client::FATAL
     ];
 
     /**
      * @throws SentryLogWriterException
-     * @return void
+     * @throws Raven_Exception
      */
     public function __construct()
     {
         // Yes, Raven_Client accepts `null`
-        $this->client = new \Raven_Client($this->getOpts());
+        $this->client = new Raven_Client($this->getOpts());
 
         // Installs all available PHP error handlers when set
         if (Config::inst()->get(__CLASS__, 'install')) {
@@ -77,22 +77,22 @@ class RavenClient extends SentryClientAdaptor
      */
     public function setData($field, $data)
     {
-        switch($field) {
-        case 'env':
-            $this->client->setEnvironment($data);
-            break;
-        case 'tags':
-            $this->client->tags_context($data);
-            break;
-        case 'user':
-            $this->client->user_context($data);
-            break;
-        case 'extra':
-            $this->client->extra_context($data);
-            break;
-        default:
-            $msg = sprintf('Unknown field "%s" passed to %s().', $field, __FUNCTION__);
-            throw new SentryLogWriterException($msg);
+        switch ($field) {
+            case 'env':
+                $this->client->setEnvironment($data);
+                break;
+            case 'tags':
+                $this->client->tags_context($data);
+                break;
+            case 'user':
+                $this->client->user_context($data);
+                break;
+            case 'extra':
+                $this->client->extra_context($data);
+                break;
+            default:
+                $msg = sprintf('Unknown field "%s" passed to %s().', $field, __FUNCTION__);
+                throw new SentryLogWriterException($msg);
         }
     }
 
@@ -116,9 +116,9 @@ class RavenClient extends SentryClientAdaptor
      */
     public function getLevel($level)
     {
-        return isset($this->client->logLevels[$level]) ?
-            $this->client->logLevels[$level] :
-            $this->client->logLevels[self::$default_error_level];
+        return isset($this->logLevels[$level]) ?
+            $this->logLevels[$level] :
+            $this->logLevels[self::$default_error_level];
     }
 
 }

--- a/src/Adaptor/SentryClientAdaptor.php
+++ b/src/Adaptor/SentryClientAdaptor.php
@@ -11,7 +11,6 @@ namespace PhpTek\Sentry\Adaptor;
 
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
-use PhpTek\Sentry\Exception\SentryClientAdaptorException;
 
 /**
  * The SentryClientAdaptor provides the base-class functionality for subclasses
@@ -66,6 +65,7 @@ abstract class SentryClientAdaptor
     abstract public function setData($field, $data);
 
     /**
+     * @param string $level
      * @return string
      */
     abstract public function getLevel($level);

--- a/src/Handler/SentryMonologHandler.php
+++ b/src/Handler/SentryMonologHandler.php
@@ -11,10 +11,13 @@ namespace PhpTek\Sentry\Handler;
 
 use Exception;
 use Monolog\Logger;
+use PhpTek\Sentry\Adaptor\RavenClient;
+use PhpTek\Sentry\Adaptor\SentryClientAdaptor;
 use PhpTek\Sentry\Log\SentryLogger;
 use PhpTek\Sentry\Monolog\Handler\SentryRavenHandler;
 use SilverStripe\Dev\Backtrace;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Monolog Handler for Sentry via Raven
@@ -22,13 +25,13 @@ use SilverStripe\Security\Member;
 class SentryMonologHandler extends SentryRavenHandler
 {
     /**
-     * @var SentryClientAdaptor
+     * @var RavenClient
      */
     protected $client;
 
     /**
-     * @param  int $level
-     * @param  bool $bubble
+     * @param  int   $level
+     * @param  bool  $bubble
      * @param  array $extras Extra parameters that will become "tags" in Sentry.
      * @return void
      */
@@ -36,8 +39,8 @@ class SentryMonologHandler extends SentryRavenHandler
     {
         // Returns an instance of {@link SentryLogger}
         $logger = SentryLogger::factory($extras);
-        $sdk = $logger->client->getSDK();
-        $this->client = $logger->client;
+        $sdk = $logger->getClient()->getSDK();
+        $this->client = $logger->getClient();
         $this->client->setData('user', $this->getUserData(null, $logger));
 
         parent::__construct($sdk, $level, $bubble);
@@ -131,13 +134,14 @@ class SentryMonologHandler extends SentryRavenHandler
      * Returns a default set of additional data specific to the user's part in
      * the request.
      *
-     * @param  Member $member
+     * @param  Member       $member
+     * @param  SentryLogger $logger
      * @return array
      */
     private function getUserData(Member $member = null, $logger)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         return [

--- a/src/Handler/SentryMonologHandler.php
+++ b/src/Handler/SentryMonologHandler.php
@@ -9,40 +9,40 @@
 
 namespace PhpTek\Sentry\Handler;
 
-use PhpTek\Sentry\Monolog\Handler\SentryRavenHandler,
-    Monolog\Logger,
-    SilverStripe\Dev\Backtrace,
-    SilverStripe\Security\Member,
-    PhpTek\Sentry\Log\SentryLogger;
+use Exception;
+use Monolog\Logger;
+use PhpTek\Sentry\Log\SentryLogger;
+use PhpTek\Sentry\Monolog\Handler\SentryRavenHandler;
+use SilverStripe\Dev\Backtrace;
+use SilverStripe\Security\Member;
 
 /**
  * Monolog Handler for Sentry via Raven
  */
-
 class SentryMonologHandler extends SentryRavenHandler
-{    
+{
     /**
      * @var SentryClientAdaptor
      */
     protected $client;
 
     /**
-     * @param  int   $level
-     * @param  bool  $bubble
+     * @param  int $level
+     * @param  bool $bubble
      * @param  array $extras Extra parameters that will become "tags" in Sentry.
      * @return void
      */
     public function __construct($level = Logger::DEBUG, $bubble = true, $extras = [])
-    {        
+    {
         // Returns an instance of {@link SentryLogger}
         $logger = SentryLogger::factory($extras);
         $sdk = $logger->client->getSDK();
         $this->client = $logger->client;
         $this->client->setData('user', $this->getUserData(null, $logger));
-        
+
         parent::__construct($sdk, $level, $bubble);
     }
-    
+
     /**
      * @return SentryClientAdaptor
      */
@@ -50,14 +50,14 @@ class SentryMonologHandler extends SentryRavenHandler
     {
         return $this->client;
     }
-    
+
     /**
-     * write() forms the entry point into the physical sending of the error. The 
+     * write() forms the entry point into the physical sending of the error. The
      * sending itself is done by the current adaptor's `send()` method.
-     * 
-     * @param  array $record An array of error-context metadata with the following 
+     *
+     * @param  array $record An array of error-context metadata with the following
      *                       available keys:
-     * 
+     *
      *                       - message
      *                       - context
      *                       - level
@@ -66,53 +66,54 @@ class SentryMonologHandler extends SentryRavenHandler
      *                       - datetime
      *                       - extra
      *                       - formatted
-     * 
+     *
      * @return void
      */
     protected function write(array $record)
-    {   
-        // The complete compliment of these data come via the Raven_Client::xxx_context() methods
-        // Monolog does not make use of the 'extra' parameter, so we munge ours into
-        // its 'context' param and use that
-        if (!$extra = !empty($record['extra']) ? $record['extra'] : []) {
-            $extra = !empty($record['context']) ? $record['context'] : [];
-        }
-
-        $record = [
-            'level'      => $record['level'],
-            'formatted'  => $record['formatted'],
-            'channel'    => $record['channel'],
+    {
+        $record = array_merge($record, [
             'timestamp'  => $record['datetime']->getTimestamp(),
-            'extra'      => $extra,
             'stacktrace' => $this->backtrace($record),
-            'stack'      => true,
-        ];
-        
+        ]);
+
         // write() calls one of RavenHandler::captureException() or RavenHandler::captureMessage()
         // depending on if $record['context']['exception'] is an instance of Exception or not
         parent::write($record);
     }
-    
+
     /**
      * Generate a cleaned-up backtrace of the event that got us here.
-     * 
+     *
      * @param  array $record
      * @return array
      */
     private function backtrace($record)
     {
+        // Provided trace
+        if (!empty($record['context']['trace'])) {
+            return $record['context']['trace'];
+        }
+
+        // Generate trace from exception
+        if (isset($record['context']['exception'])) {
+            /** @var Exception $exception */
+            $exception = $record['context']['exception'];
+            return $exception->getTrace();
+        }
+
+        // Failover: build custom trace
         $bt = debug_backtrace();
-            
+
         // Push current line into context
         array_unshift($bt, [
-            'file' => !empty($bt['file']) ? $bt['file'] : 'N/A',
-            'line' => !empty($bt['line']) ? $bt['line'] : 'N/A',
+            'file'     => !empty($bt['file']) ? $bt['file'] : 'N/A',
+            'line'     => !empty($bt['line']) ? $bt['line'] : 'N/A',
             'function' => '',
-            'class' => '',
-            'type' => '',
-            'args' => [],
+            'class'    => '',
+            'type'     => '',
+            'args'     => [],
         ]);
-        
+
         $bt = Backtrace::filter_backtrace($bt, [
             '',
             'Monolog\\Handler\\AbstractProcessingHandler->handle',
@@ -122,14 +123,14 @@ class SentryMonologHandler extends SentryRavenHandler
             'PhpTek\\Sentry\\Handler\\SentryMonologHandler->write',
             'PhpTek\\Sentry\\Handler\\SentryMonologHandler->backtrace',
         ]);
-        
+
         return $bt;
     }
-    
+
     /**
      * Returns a default set of additional data specific to the user's part in
      * the request.
-     * 
+     *
      * @param  Member $member
      * @return array
      */
@@ -138,12 +139,11 @@ class SentryMonologHandler extends SentryRavenHandler
         if (!$member) {
             $member = Member::currentUser();
         }
-        
+
         return [
-            'IPddress'  => $logger->getIP(),
-            'ID'        => $member ? $member->getField('ID') : SentryLogger::SLW_NOOP,
-            'Email'     => $member ? $member->getField('Email') : SentryLogger::SLW_NOOP,
+            'IPddress' => $logger->getIP(),
+            'ID'       => $member ? $member->getField('ID') : SentryLogger::SLW_NOOP,
+            'Email'    => $member ? $member->getField('Email') : SentryLogger::SLW_NOOP,
         ];
     }
-    
 }

--- a/src/Handler/SentryRavenHandler.php
+++ b/src/Handler/SentryRavenHandler.php
@@ -80,10 +80,10 @@ class SentryRavenHandler extends RavenHandler
             $options['extra']['extra'] = $record['extra'];
         }
 
-        // New for phptek/sentry
+        // Save stack
         $stack = false;
-        if (!empty($record['stack'])) {
-            $stack = (bool) $record['stack'];
+        if (!empty($record['stacktrace'])) {
+            $stack = $record['stacktrace'];
         }
 
         if (!empty($this->release) && !isset($options['release'])) {

--- a/src/Log/SentryLogger.php
+++ b/src/Log/SentryLogger.php
@@ -9,9 +9,10 @@
 
 namespace PhpTek\Sentry\Log;
 
-use SilverStripe\Control\Director,
-    SilverStripe\Core\Injector\Injector,
-    SilverStripe\Control\Middleware\TrustedProxyMiddleware;
+use PhpTek\Sentry\Adaptor\RavenClient;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\Middleware\TrustedProxyMiddleware;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * The SentryLogWriter class simply acts as a bridge between the configured Sentry
@@ -24,6 +25,10 @@ use SilverStripe\Control\Director,
 
 class SentryLogger
 {
+    /**
+     * @var RavenClient
+     */
+    public $client = null;
 
     /**
      * Stipulates what gets shown in the Sentry UI, should some metric not be
@@ -46,6 +51,7 @@ class SentryLogger
         $env = isset($config['env']) ? $config['env'] : null;
         $tags = isset($config['tags']) ? $config['tags'] : [];
         $extra = isset($config['extra']) ? $config['extra'] : [];
+        /** @var SentryLogger $logger */
         $logger = Injector::inst()->create(__CLASS__);
 
         // Set default environment
@@ -69,7 +75,7 @@ class SentryLogger
     /**
      * Used in unit tests.
      *
-     * @return SentryClientAdaptor
+     * @return RavenClient
      */
     public function getClient()
     {


### PR DESCRIPTION
@phptek Sentry had been only ever rendering stack traces for the error handling classes themselves; These are not so useful when trying to diagnose the actual issue. :)

Tested on both fatal errors, as well as exceptions.

Uses the work I did at https://github.com/Seldaek/monolog/pull/1080 to capture non-exception traces as well. :)