### PR TITLE
3.0: Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Add the Composer package as a dependency to your project:
 Note that 2.x and 3.x should work with the same setups, the latter simply uses a
 newer version of the Sentry PHP SDK, and has a leaner codebase.
 
+The only change with 3.x is that `SentryClientAdaptor` has been renamed to `SentryAdaptor`,
+meaning your configuration will have to be updated accordingly.
+
 Configure your application or site with the Sentry DSN into your project's YML config:
 
 ### SilverStripe 4
@@ -48,7 +51,7 @@ Configure your application or site with the Sentry DSN into your project's YML c
 
 The following YML config will get you errors reported in all environment modes: `dev`, `test` and `live`: 
 
-    PhpTek\Sentry\Adaptor\SentryClientAdaptor:
+    PhpTek\Sentry\Adaptor\SentryAdaptor:
       opts:
         # Example DSN only. Obviously you'll need to setup your own Sentry "Project"
         dsn: http://deacdf9dfedb24ccdce1b90017b39dca:deacdf9dfedb24ccdce1b90017b39dca@sentry.mydomain.nz/44
@@ -61,7 +64,7 @@ The following YML config will get you errors reported just in `test` and `live` 
     Only:
       environment: test
     ---
-    PhpTek\Sentry\Adaptor\SentryClientAdaptor:
+    PhpTek\Sentry\Adaptor\SentryAdaptor:
       opts:
         # Example DSN only. Obviously you'll need to setup your own Sentry "Project"
         dsn: http://deacdf9dfedb24ccdce1b90017b39dca:deacdf9dfedb24ccdce1b90017b39dca@sentry.mydomain.nz/44
@@ -69,7 +72,7 @@ The following YML config will get you errors reported just in `test` and `live` 
     Except:
       environment: test
     ---
-    PhpTek\Sentry\Adaptor\SentryClientAdaptor:
+    PhpTek\Sentry\Adaptor\SentryAdaptor:
       opts:
         # Example DSN only. Obviously you'll need to setup your own Sentry "Project"
         dsn: http://deacdf9dfedb24ccdce1b90017b39dca:deacdf9dfedb24ccdce1b90017b39dca@sentry.mydomain.nz/44
@@ -77,7 +80,7 @@ The following YML config will get you errors reported just in `test` and `live` 
     Only:
       environment: dev
     ---
-    PhpTek\Sentry\Adaptor\SentryClientAdaptor:
+    PhpTek\Sentry\Adaptor\SentryAdaptor:
       opts:
         dsn: null
     ---

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,8 @@ Name: sentry-config
 ---
 
 PhpTek\Sentry\Log\SentryLogger:
+  # One of the permitted severities: DEBUG|INFO|WARNING|ERROR|FATAL
+  log_level: WARNING
   dependencies:
     adaptor: %$PhpTek\Sentry\Adaptor\SentryAdaptor
 

--- a/src/Adaptor/SentryAdaptor.php
+++ b/src/Adaptor/SentryAdaptor.php
@@ -24,7 +24,7 @@ use SilverStripe\Core\Injector\Injector;
 class SentryAdaptor
 {
     use Configurable;
-    
+
     /**
      * It's an ERROR unless proven otherwise!
      *
@@ -37,7 +37,7 @@ class SentryAdaptor
      * @var ClientInterface
      */
     protected $sentry;
-        
+
     /**
      * A mapping of log-level values between Zend_Log => Raven_Client
      *
@@ -104,7 +104,7 @@ class SentryAdaptor
                 break;
             case 'level':
                 Hub::getCurrent()->configureScope(function (Scope $scope) use($data) : void {
-                    $scope->setLevel($data);
+                    $scope->setLevel(new Severity(strtolower($data)));
                 });
                 break;
             default:
@@ -122,13 +122,13 @@ class SentryAdaptor
     {
         $options = Hub::getCurrent()->getClient()->getOptions();
         $data = [];
-        
+
         Hub::getCurrent()->configureScope(function (Scope $scope) use (&$data) : void {
                 $data['user'] = $scope->getUser();
                 $data['tags'] = $scope->getTags();
                 $data['extra'] = $scope->getExtra();
         });
-        
+
         return [
             'env'   => $options->getEnvironment(),
             'tags'  => $data['tags'] ?? [],

--- a/src/Handler/SentryHandler.php
+++ b/src/Handler/SentryHandler.php
@@ -36,7 +36,7 @@ class SentryHandler extends AbstractProcessingHandler
         $logger = SentryLogger::factory($extras);
         $this->client = $logger->getAdaptor();
 
-        parent::__construct($this->client->getSDK(), $level, $bubble);
+        parent::__construct($level, $bubble);
     }
 
     /**
@@ -73,7 +73,7 @@ class SentryHandler extends AbstractProcessingHandler
             $this->client->getSDK()->captureMessage($record['formatted'], new Severity(strtolower($record['level_name'])));
         }
     }
-    
+
     /**
      * @return SentryAdaptor
      */


### PR DESCRIPTION
Finally had a chance to play around w/ the 3.0 branch.

Found a few bugs that caused errors, which we sorted. The biggest thing however is that the `SentryClientAdaptor` class was renamed to `SentryAdaptor`, meaning that the config needs to be updated when moving to 3.0

For now I've just put a note in the README, and updated the config examples, but it might be nicer to revert the renaming.