### PR TITLE
Log level configuration for 2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ be after the module's config, thus:
 This is because a baked-in dummy DSN needed to be added to the module's config for unit-testing. This will
 need to remain in-place until the tests can be fixed to use the `Config` system properly.
 
+#### Log Level ####
+
+You can set the minimum log-level you're interested in, using the `log_level` config:
+
+For version 2.0.x:
+```
+PhpTek\Sentry\Handler\SentryMonologHandler:
+  # One of the permitted severities: DEBUG|INFO|NOTICE|WARNING|ERROR|CRITICAL|FATAL|EMERGENCY
+  log_level: WARNING
+```
+
+For version 3.0.x:
+```
+PhpTek\Sentry\Log\SentryLogger:
+  # One of the permitted severities: DEBUG|INFO|WARNING|ERROR|FATAL
+  log_level: WARNING
+```
+
+If you're interested to know how Sentry itself maps its own categories of message to
+PHP's internals, see the `fromError()` method here: https://github.com/getsentry/sentry-php/blob/master/src/Severity.php
+
+
 ### SilverStripe 3
 
     phptek\Sentry\Adaptor\SentryClientAdaptor:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,6 +3,7 @@ Name: sentryconfig
 ---
 
 PhpTek\Sentry\Log\SentryLogger:
+  log_level: WARNING
   dependencies:
     client: %$PhpTek\Sentry\Adaptor\RavenClient
     

--- a/src/Handler/SentryMonologHandler.php
+++ b/src/Handler/SentryMonologHandler.php
@@ -15,6 +15,7 @@ use PhpTek\Sentry\Adaptor\RavenClient;
 use PhpTek\Sentry\Adaptor\SentryClientAdaptor;
 use PhpTek\Sentry\Log\SentryLogger;
 use PhpTek\Sentry\Monolog\Handler\SentryRavenHandler;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\Backtrace;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
@@ -35,13 +36,16 @@ class SentryMonologHandler extends SentryRavenHandler
      * @param  array $extras Extra parameters that will become "tags" in Sentry.
      * @return void
      */
-    public function __construct($level = Logger::DEBUG, $bubble = true, $extras = [])
+    public function __construct($level = Logger::WARNING, $bubble = true, $extras = [])
     {
         // Returns an instance of {@link SentryLogger}
         $logger = SentryLogger::factory($extras);
         $sdk = $logger->getClient()->getSDK();
         $this->client = $logger->getClient();
         $this->client->setData('user', $this->getUserData(null, $logger));
+
+        $log_level = Config::inst()->get(self::class, 'log_level');
+        $level = ($log_level) ? constant(Logger::class . '::'. $log_level) : $level;
 
         parent::__construct($sdk, $level, $bubble);
     }

--- a/src/Tasks/TestConnectionTask.php
+++ b/src/Tasks/TestConnectionTask.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PhpTek\Sentry\Tasks;
+
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\BuildTask;
+
+class TestConnectionTask extends BuildTask
+{
+    /** @var string */
+    protected $title = 'Test Sentry Configuration';
+
+    /** @var string */
+    protected $description = 'Captures message for all levels available';
+
+    /**
+     * Implement this method in the task subclass to
+     * execute via the TaskRunner
+     *
+     * @param \SilverStripe\Control\HTTPRequest|null $request
+     */
+    public function run($request = null)
+    {
+        /** @var LoggerInterface $logger */
+        $logger = Injector::inst()->get(LoggerInterface::class);
+
+        foreach (Logger::getLevels() as $name => $value) {
+            $func = strtolower($name);
+            $logger->$func(sprintf("Testing Severity Level: %s", $name));
+            self::output(sprintf("Security Level: %s", $name));
+        }
+    }
+
+    private static function output(string $message)
+    {
+        $newLine = Director::is_cli() ? PHP_EOL : '<br/>';
+        printf($message . $newLine);
+    }
+}


### PR DESCRIPTION
Added configuration for minimal log level config on 2.0.x

Parameter name is the same as what has been implemented for 3.0.x

Update README accordingly.