### PR TITLE
Missing class dependency

### DIFF
--- a/src/Tasks/TestConnectionTask.php
+++ b/src/Tasks/TestConnectionTask.php
@@ -4,6 +4,7 @@ namespace PhpTek\Sentry\Tasks;
 
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
 


### PR DESCRIPTION
Causes an exception when triggering task.

