### PR TITLE
FIX: Fixes #42 #26 Added stacktrace to non-exception messages

### DIFF
--- a/src/Adaptor/SentryAdaptor.php
+++ b/src/Adaptor/SentryAdaptor.php
@@ -31,11 +31,11 @@ class SentryAdaptor
      * @var ClientInterface
      */
     protected $sentry;
-    
+
     /**
      * Internal storage for context. Used only in the case of non-exception
      * data sent to Sentry.
-     * 
+     *
      * @var array
      */
     protected $context = [];
@@ -62,7 +62,7 @@ class SentryAdaptor
     /**
      * Configures Sentry "context" to display additional information about a SilverStripe
      * application's runtime and context.
-     * 
+     *
      * @param  string $field
      * @param  mixed  $data
      * @return void
@@ -71,7 +71,8 @@ class SentryAdaptor
     public function setContext(string $field, $data) : void
     {
         $options = Hub::getCurrent()->getClient()->getOptions();
-        
+        $options->setAttachStacktrace(true);
+
         switch ($field) {
             case 'env':
                 $options->setEnvironment($data);
@@ -109,18 +110,15 @@ class SentryAdaptor
                 throw new SentryLogWriterException($msg);
         }
     }
-    
+
     /**
      * Get _locally_ set contextual data, that we should be able to get from Sentry's
      * current {@link Scope}.
-     * 
-     * Note: This (re) sets data to a new instance of {@link Scope} for passing to 
+     *
+     * Note: This (re) sets data to a new instance of {@link Scope} for passing to
      * captureMessage(). One would expect this to be set by default, as it is for
      * $record data sent to Sentry via captureException(), but it isn't.
-     * 
-     * @todo Investigate sentry/php-sdk's API for alternative ways to handle "manual"
-     * logging, where data is not an exception and results in being passed to captureMessage().
-     * 
+     *
      * @return Scope
      */
     public function getContext() : Scope
@@ -128,15 +126,15 @@ class SentryAdaptor
         $scope = new Scope();
 
         $scope->setUser($this->context['user']);
-        
+
         foreach ($this->context['tags'] as $tagKey => $tagData) {
             $scope->setTag($tagKey, $tagData);
         }
-        
+
         foreach ($this->context['extra'] as $extraKey => $extraData) {
             $scope->setExtra($extraKey, $extraData);
         }
-        
+
         return $scope;
     }
 
@@ -150,7 +148,7 @@ class SentryAdaptor
     protected function getOpts(string $opt = '')
     {
         $opts = [];
-        
+
         // Extract env-vars from YML config or env
         if ($dsn = Env::getEnv('SENTRY_DSN')) {
             $opts['dsn'] = $dsn;

--- a/src/Adaptor/SentrySeverity.php
+++ b/src/Adaptor/SentrySeverity.php
@@ -17,7 +17,7 @@ use Sentry\Severity;
  */
 class SentrySeverity
 {
-        /**
+    /**
      * Maps PHP's internal error-types into those suited to {@link Severity}.
      *
      * @param  mixed int|string $severity The incoming level from userland code or
@@ -26,7 +26,7 @@ class SentrySeverity
      */
     public static function process_severity($severity) : string
     {
-        // Stringified PHP severities out of \backtrace() like "notice"
+        // Stringified PHP severities out of \debug_backtrace() like "notice"
         if (is_string($severity)) {
             $level = self::from_error($severity);
         // De-facto PHP severities as constants (ints) like E_NOTICE
@@ -43,14 +43,14 @@ class SentrySeverity
     /**
      * Almost an exact replica of {@link Severity::fromError()}, except we're
      * dealing with string values passed to us from upstream processes.
-     * 
+     *
      * @param  string $severity An incoming severity.
      * @return string
      */
     public static function from_error(string $severity) : string
     {
         $severity = strtolower($severity);
-        
+
         switch ($severity) {
             case 'deprecated':
             case 'user_deprecated':
@@ -76,5 +76,5 @@ class SentrySeverity
                 return Severity::ERROR;
         }
     }
-    
+
 }


### PR DESCRIPTION
- Added current scope/context to both types of message
- Improved the backtrace() method (but is currently doing nothing - see comments)
- Minor boyscouting