### PR TITLE
Minimum Error Log and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Notes:
 You can set the minimum log-level you're interested in, using the `log_level` config, the module default is to report anything more severe than a `WARNING`:
 
 ```
-PhpTek\Sentry\Log\SentryLogger:
+PhpTek\Sentry\Handler\SentryHandler:
   # One of the permitted severities: DEBUG|INFO|WARNING|ERROR|FATAL
-  log_level: WARNING
+  log_level: ERROR
 ```
 
 ### SilverStripe 3

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,8 +3,6 @@ Name: sentry-config
 ---
 
 PhpTek\Sentry\Log\SentryLogger:
-  # One of the permitted severities: DEBUG|INFO|WARNING|ERROR|FATAL
-  log_level: WARNING
   dependencies:
     adaptor: %$PhpTek\Sentry\Adaptor\SentryAdaptor
 

--- a/src/Adaptor/SentryAdaptor.php
+++ b/src/Adaptor/SentryAdaptor.php
@@ -9,6 +9,7 @@
 
 namespace PhpTek\Sentry\Adaptor;
 
+use PhpTek\Sentry\Exception\SentryLogWriterException;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
 use Sentry\State\Scope;
@@ -17,7 +18,6 @@ use Sentry\Severity;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Environment as Env;
-use PhpTek\Sentry\Adaptor\SentrySeverity;
 
 /**
  * The SentryAdaptor provides a functionality bridge between the getsentry/sentry
@@ -46,7 +46,7 @@ class SentryAdaptor
     public function __construct()
     {
         $client = ClientBuilder::create($this->getOpts() ?: [])->getClient();
-        Hub::setCurrent(new Hub($client));
+        Hub::getCurrent()->bindClient($client);
 
         $this->sentry = $client;
     }

--- a/src/Handler/SentryHandler.php
+++ b/src/Handler/SentryHandler.php
@@ -13,6 +13,7 @@ use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Sentry\Severity;
 use Sentry\State\Scope;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use PhpTek\Sentry\Log\SentryLogger;
 use PhpTek\Sentry\Adaptor\SentryAdaptor;
@@ -25,7 +26,16 @@ use PhpTek\Sentry\Adaptor\SentrySeverity;
 class SentryHandler extends AbstractProcessingHandler
 {
 
-    use Injectable;
+    use Injectable,
+        Configurable;
+
+    /**
+     * @config
+     */
+    private static $log_level = null;
+
+    /** @var SentryAdaptor|null */
+    private $client = null;
 
     /**
      * @param  int     $level
@@ -33,11 +43,16 @@ class SentryHandler extends AbstractProcessingHandler
      * @param  array   $extras
      * @return void
      */
-    public function __construct(int $level = Logger::DEBUG, bool $bubble = true, array $extras = [])
+    public function __construct(int $level = Logger::WARNING, bool $bubble = true, array $extras = [])
     {
         // Returns an instance of {@link SentryLogger}
         $logger = SentryLogger::factory($extras);
         $this->client = $logger->getAdaptor();
+
+        // Override minimum log level through configuration
+        if (SentryHandler::config()->log_level) {
+            $level = SentryHandler::config()->log_level;
+        }
 
         parent::__construct($level, $bubble);
     }

--- a/src/Log/SentryLogger.php
+++ b/src/Log/SentryLogger.php
@@ -29,7 +29,7 @@ class SentryLogger
     /**
      * @var SentryAdaptor
      */
-    public $client = null;
+    public $adaptor = null;
 
     /**
      * Stipulates what gets shown in the Sentry UI, should some metric not be
@@ -53,8 +53,7 @@ class SentryLogger
         $user = $config['user'] ?? [];
         $tags = $config['tags'] ?? [];
         $extra = $config['extra'] ?? [];
-        // Set the minimum reporting level
-        $level = $config['level'] ?? self::config()->get('log_level');
+        $level = $config['level'] ?? [];
         $logger = Injector::inst()->create(static::class);
 
         // Set default environment


### PR DESCRIPTION
- Binds adaptor to existing Hub instead of creating an independent one
- Unnecessary default as the default minimum log level is set in the SentryHandler constructor directly
- Adds Configurable properties to SentryHandler. Set log_level in configuration in order to override value passed on construction.
- Sets default log_level value to WARNING in constructor as expected default for the module
- Updates README accordingly
- Remove deafult from Injection tro SentryAdaptor as it does not define what's the minimum report level