### PR TITLE
Fix issue with string quotes crashing updated symfony/yml

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,9 +4,9 @@ Name: sentry-config
 
 PhpTek\Sentry\Log\SentryLogger:
   dependencies:
-    adaptor: %$PhpTek\Sentry\Adaptor\SentryAdaptor
+    adaptor: '%$PhpTek\Sentry\Adaptor\SentryAdaptor'
 
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface:
     calls:
-      - [ pushHandler, [ %$PhpTek\Sentry\Handler\SentryHandler ]]
+      - [ pushHandler, [ '%$PhpTek\Sentry\Handler\SentryHandler' ]]


### PR DESCRIPTION
Latest update to symfony/yml now whinges about `%` characters :) Quoting resolves this.