### PR TITLE
Capture messages without timestamps in the title

### DIFF
--- a/src/Handler/SentryHandler.php
+++ b/src/Handler/SentryHandler.php
@@ -138,7 +138,7 @@ class SentryHandler extends AbstractProcessingHandler
             }
 
             $this->client->captureMessage(
-                $record['formatted'],
+                $record['context']['message'],
                 new Severity(SentrySeverity::process_severity($record['level_name'])),
                 $adaptor->getContext(),
                 $eventHint


### PR DESCRIPTION
Allows the Sentry UI to properly group related issues. The `formatted` property includes a timestamp, which causes Sentry to log them as separate issues.

See the attached screenshot for an example. There are two missing CSS files which Silverstripe is trying to link into the page. The first four entries show the current behaviour where each time the page is loaded, a new _Issue_ is logged in Sentry due to the timestamp.

The bottom two rows are with the PR applied - similar events are grouped with the original.

![Screen Shot 2021-09-28 at 5 07 09 PM](https://user-images.githubusercontent.com/2873649/135023381-2d11adda-eef7-4053-8243-aef332119f93.png)

