### PR TITLE
Allow Silverstripe 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7|^8",
         "sentry/sdk": "^3",
         "composer/package-versions-deprecated": "^1.11",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4 | ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
I tried installing this on Silverstripe 5. Initially just added a || ^5 to composer.json, but there's some underlying fixes to the library that need to be made:

* [x] `protected function write(array $record): void => protected function write(Monolog\LogRecord $record): void`
* [x] PHP Fatal error:  Uncaught Error: Call to undefined method Monolog\Logger::getLevels() in /var/www/html/vendor/phptek/sentry/src/Handler/SentryHandler.php:67