### PR TITLE
fix null ip

### DIFF
--- a/src/Log/SentryLogger.php
+++ b/src/Log/SentryLogger.php
@@ -259,7 +259,7 @@ class SentryLogger
         if (Controller::has_curr()) {
             $controller = Controller::curr();
             if ($request = $controller->getRequest()) {
-                return $request->getIP();
+                return $request->getIP() ?? '';
             }
         }
 


### PR DESCRIPTION
Fixes Error: Uncaught TypeError: PhpTek\Sentry\Log\SentryLogger::get_ip(): Return value must be of type string, null returned

recently got this in my logs
not sure how it happened, but it doesn't hurt to make sure we don't get a null value