### PR TITLE
Performance Monitoring

### DIFF
--- a/src/Handler/SentryHandler.php
+++ b/src/Handler/SentryHandler.php
@@ -72,7 +72,10 @@ class SentryHandler extends AbstractProcessingHandler
         $level = Level::fromName($level ?? Level::Debug->getName());
 
         SentrySdk::setCurrentHub(new Hub($client));
-        
+
+        $trace_sample_rate = SentryAdaptor::get_opts()['traces_sample_rate'] ?? null;
+        $config['traces_sample_rate'] = $trace_sample_rate ?: 0.0;
+
         $config['level'] = $level;
 
         $this->logger = SentryLogger::factory($client, $config);

--- a/src/Log/SentryLogger.php
+++ b/src/Log/SentryLogger.php
@@ -69,6 +69,8 @@ class SentryLogger
         $env = $logger->defaultEnv();
         $tags = $logger->defaultTags();
         $extra = $logger->defaultExtra();
+        $traces_sample_rate = $logger->defaultTracesSample();
+
         $user = [];
         $level = Logger::DEBUG;
 
@@ -78,15 +80,25 @@ class SentryLogger
             $extra = array_merge($extra, $config['extra'] ?? []);
             $user = $config['user'] ?? $user;
             $level = $config['level'] ?? $level;
+            $traces_sample_rate = $config['traces_sample_rate'] ?? $traces_sample_rate;
         }
 
         $adaptor = (new SentryAdaptor($client))
             ->setContext('env', $env)
             ->setContext('tags', $tags)
             ->setContext('extra', $extra)
-            ->setContext('user', $user);
+            ->setContext('user', $user)
+            ->setContext('traces_sample_rate', $traces_sample_rate);
 
-        return $logger->setAdaptor($adaptor);
+
+        $set_adaptor = $logger->setAdaptor($adaptor);
+
+        // trigger the performance tracing if set
+        if ($traces_sample_rate) {
+            $set_adaptor->getAdaptor()->startTransaction();
+        }
+
+        return $set_adaptor;
     }
 
     /**
@@ -159,6 +171,16 @@ class SentryLogger
         return [
             'PHP Peak Memory' => self::get_peak_memory(),
         ];
+    }
+
+    /**
+     * Returns a default empty array for traces_sample_rate, as this should be blank if not set manually
+     *
+     * @return array
+     */
+    public function defaultTracesSample(): array
+    {
+        return [];
     }
 
     /**


### PR DESCRIPTION
Hi @phptek as per your previous comment on #93 here is my current status of work, it's not a lot, but it does fire them off. You obviously need your DSN set, and for this implementation you need to set `SENTRY_TRACES_SAMPLE_RATE` as an `.env` variable. 

`1` will mean everything is logged, which is useful for testing, and Sentry recommend using `0.20` for production, so only 1 in 5 requests are actually logged. You could reduce this if needing an even smaller sample size, but this appeared to be working as expected in my basic testing. This information will need to be added to the `README.md` which I have not done yet.

Feel free to contribute, or offer advice here for this to be rounded out. The last actual feature needs to be the management of the `Transaction`'s life-cycle, where in `SentryAdaptor.php:192`'s function `startTransaction()` you will see that it starts and ends it straight away. It has to be started at the beginning of the request, and ended at the closing of it for the timings to actually make sense, or as something similar that is as close to the metal that is reasonable. I'm not quite sure how to hook into this yet - at least in an elegant way. My initial thought was to include an extension of the request handler itself, but that might be the wrong direction.

It is also likely that there is some missing data when it comes to stack tracing the performance monitoring, but presumably when it's plugged into the life-cycle properly it will have a lot more context available to it as well.